### PR TITLE
Update `trust-dns-resolver` -> `hickory-resolver` in order to address security vulnerability in `idna` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.95"
 signed-json = { git = "https://github.com/erikjohnston/rust-signed-json.git" }
 tokio = { version = "1.27.0", features = ["macros"] }
 tokio-rustls = "0.24.0"
-trust-dns-resolver = "0.22.0"
+hickory-resolver = "0.24.2"
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ signed-json = { git = "https://github.com/erikjohnston/rust-signed-json.git" }
 tokio = { version = "1.27.0", features = ["macros"] }
 tokio-rustls = "0.24.0"
 hickory-resolver = "0.24.2"
-url = "2.3.1"
+url = "2.5.4"

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -13,7 +13,7 @@ use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio_rustls::rustls::ClientConfig;
-use trust_dns_resolver::error::ResolveErrorKind;
+use hickory_resolver::error::ResolveErrorKind;
 use url::Url;
 
 use std::collections::BTreeMap;
@@ -48,13 +48,13 @@ pub struct Endpoint {
 /// A resolver for Matrix server names.
 #[derive(Debug, Clone)]
 pub struct MatrixResolver {
-    resolver: trust_dns_resolver::TokioAsyncResolver,
+    resolver: hickory_resolver::TokioAsyncResolver,
 }
 
 impl MatrixResolver {
     /// Create a new [`MatrixResolver`]
     pub async fn new() -> Result<MatrixResolver, Error> {
-        let resolver = trust_dns_resolver::TokioAsyncResolver::tokio_from_system_conf()?;
+        let resolver = hickory_resolver::TokioAsyncResolver::tokio_from_system_conf()?;
 
         Ok(MatrixResolver { resolver })
     }


### PR DESCRIPTION
Update `trust-dns-resolver` -> `hickory-resolver` in order to address security vulnerability in `idna` dependency

See https://rustsec.org/advisories/RUSTSEC-2024-0421

> ## Remedy
>
> Upgrade to `idna` 1.0.3 or later, if depending on `idna` directly, or to `url` 2.5.4 or later, if depending on `idna` via `url`. (This issue was fixed in `idna` 1.0.0, but versions earlier than 1.0.3 are not recommended for other reasons.)


### Why `trust-dns-resolver` -> `hickory-resolver`?

We moved from `trust-dns-resolver` -> `hickory-resolver` because the project went through a rename:

> NOTICE This project has been rebranded to Hickory DNS and has been moved to the https://github.com/hickory-dns/hickory-dns organization and repo, this crate/binary has been moved to [hickory-resolver](https://crates.io/crates/hickory-resolver), from 0.24 and onward.

More context: https://bluejekyll.github.io/blog/posts/announcing-hickory-dns/


### Dev notes

```sh
$ cargo tree -i idna
idna v1.0.3
├── hickory-proto v0.24.2
│   └── hickory-resolver v0.24.2
│       └── matrix-hyper-federation-client v0.1.0 (/home/eric/Documents/github/element/fork-matrix-hyper-federation-client)
└── url v2.5.4
    ├── hickory-proto v0.24.2 (*)
    └── matrix-hyper-federation-client v0.1.0 (/home/eric/Documents/github/element/fork-matrix-hyper-federation-client)
```
