### PR TITLE
Update `http` dependency to `1.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,13 @@ http = "1.2.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.6.0", features = ["client", "http1", "server"] }
 hyper-rustls = "0.27.5"
-hyper-util = { version = "0.1.10", features = ["server", "service"] }
+hyper-util = { version = "0.1.10", features = [
+  "client",
+  "client-legacy",
+  "server",
+  "service",
+  "tokio",
+] }
 log = "0.4.17"
 rand = "0.8.5"
 serde = { version = "1.0.159", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,6 @@ serde_json = "1.0.95"
 signed-json = { git = "https://github.com/erikjohnston/rust-signed-json.git" }
 tokio = { version = "1.27.0", features = ["macros"] }
 tokio-rustls = "0.26.1"
+tower-service = "0.3.3"
 hickory-resolver = "0.24.2"
 url = "2.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ http = "1.2.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.6.0", features = ["client", "http1", "server"] }
 hyper-rustls = "0.27.5"
-hyper-util = { version = "0.1.10", features = ["server"] }
+hyper-util = { version = "0.1.10", features = ["server", "service"] }
 log = "0.4.17"
 rand = "0.8.5"
 serde = { version = "1.0.159", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,22 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.70"
 base64 = "0.21.0"
+bytes = "1.10.0"
 doc-comment = "0.3.3"
 ed25519-dalek = "2.0.0"
 futures = "0.3.28"
 futures-util = "0.3.28"
-http = "0.2.9"
-hyper = { version = "0.14.25", features = ["client", "http1", "server", "stream"] }
-hyper-rustls = "0.24.0"
+http = "1.2.0"
+http-body-util = "0.1.2"
+hyper = { version = "1.6.0", features = ["client", "http1", "server"] }
+hyper-rustls = "0.27.5"
+hyper-util = { version = "0.1.10", features = ["server"] }
 log = "0.4.17"
 rand = "0.8.5"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 signed-json = { git = "https://github.com/erikjohnston/rust-signed-json.git" }
 tokio = { version = "1.27.0", features = ["macros"] }
-tokio-rustls = "0.24.0"
+tokio-rustls = "0.26.1"
 hickory-resolver = "0.24.2"
 url = "2.5.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -69,7 +69,7 @@ impl FederationClient {
 /// signed.
 #[derive(Debug, Clone)]
 pub struct SigningFederationClient<C = MatrixConnector> {
-    client: Client<C>,
+    client: Client<C, Full<Bytes>>,
     server_name: String,
     key_id: String,
     secret_key: Arc<SigningKey>,
@@ -99,7 +99,7 @@ impl<C> SigningFederationClient<C> {
     /// Note, the connector used by the [`Client`] must support `matrix://` and
     /// `matrix-federation://` URIs.
     pub fn with_client(
-        client: Client<C>,
+        client: Client<C, Full<Bytes>>,
         server_name: String,
         key_name: String,
         secret_key: SigningKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //!
 //! # [`FederationClient`]
 //!
-//! The [`FederationClient`] is just a standard [`hyper::Client`] with a
-//! [`MatrixConnector`] that can route `matrix://` and `matrix-federation://` URIs, but
-//! does *not* sign the requests automatically:
+//! The [`FederationClient`] is just a standard [`hyper_util::client::legacy::Client`]
+//! with a [`MatrixConnector`] that can route `matrix://` and `matrix-federation://`
+//! URIs, but does *not* sign the requests automatically:
 //!
 //! ```no_run
 //! # use matrix_hyper_federation_client::FederationClient;

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -1,6 +1,7 @@
 //! Module for resolving Matrix server names.
 
 use std::collections::BTreeMap;
+use std::convert::TryInto;
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
@@ -380,7 +381,12 @@ impl Service<Uri> for MatrixConnector {
                 let mut https = hyper_rustls::HttpsConnectorBuilder::new()
                     .with_tls_config(client_config.clone())
                     .https_only()
-                    .with_server_name(endpoint.tls_name.clone())
+                    .with_server_name_resolver(hyper_rustls::FixedServerNameResolver::new(
+                        endpoint.tls_name.clone().try_into().context(format!(
+                            "failed to create `ServerName` from `endpoint.tls_name`: {}",
+                            endpoint.tls_name
+                        ))?,
+                    ))
                     .enable_http1()
                     .build();
 

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -374,7 +374,7 @@ impl Service<Uri> for MatrixConnector {
             for endpoint in endpoints {
                 debug!("Connecting to endpoint {:?}", endpoint);
 
-                let mut https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+                let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
                     .with_tls_config(client_config.clone())
                     .https_only()
                     .with_server_name(endpoint.tls_name.clone())

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -14,7 +14,7 @@ use hickory_resolver::error::ResolveErrorKind;
 use http::header::{HOST, LOCATION};
 use http::{Request, Uri};
 use http_body_util::{BodyExt, Full};
-use hyper_rustls::MaybeHttpsStream;
+use hyper_rustls::{ConfigBuilderExt, MaybeHttpsStream};
 use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioIo;
@@ -311,8 +311,8 @@ impl MatrixConnector {
     /// Create new [`MatrixConnector`] with the given [`MatrixResolver`].
     pub fn with_resolver(resolver: MatrixResolver) -> MatrixConnector {
         let client_config = ClientConfig::builder()
-            .with_safe_defaults()
             .with_native_roots()
+            .unwrap()
             .with_no_client_auth();
 
         MatrixConnector {

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -5,18 +5,18 @@ use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::task::{self, Poll};
 
 use anyhow::{format_err, Context, Error};
+use bytes::Bytes;
 use futures::FutureExt;
-use futures_util::stream::StreamExt;
 use hickory_resolver::error::ResolveErrorKind;
 use http::header::{HOST, LOCATION};
 use http::{Request, Uri};
-use hyper::client::connect::Connect;
+use http_body_util::{BodyExt, Full};
 use hyper::service::Service;
-use hyper::{Body, Client};
-use hyper_rustls::{ConfigBuilderExt, MaybeHttpsStream};
+use hyper_rustls::MaybeHttpsStream;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
@@ -186,7 +186,10 @@ impl MatrixResolver {
 }
 
 /// Check if there is a `.well-known` file present on the given host.
-pub async fn get_well_known<C>(http_client: &Client<C>, host: &str) -> Option<WellKnownServer>
+pub async fn get_well_known<C>(
+    http_client: &Client<C, Full<Bytes>>,
+    host: &str,
+) -> Option<WellKnownServer>
 where
     C: Connect + Clone + Sync + Send + 'static,
 {
@@ -224,16 +227,8 @@ where
             };
         }
 
-        let mut body = resp.into_body();
-
-        let mut vec = Vec::new();
-        while let Some(next) = body.next().await {
-            // TODO: Limit size of body.
-            let chunk = next.ok()?;
-            vec.extend(chunk);
-        }
-
-        return serde_json::from_slice(&vec).ok();
+        let bytes = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        return serde_json::from_slice(&bytes).ok();
     }
 
     debug!("Redirection loop exhausted");
@@ -244,9 +239,9 @@ where
 /// Check if the request is pointing at a delegated server, and if so replace
 /// with delegated info.
 pub async fn handle_delegated_server<C>(
-    http_client: &Client<C>,
-    mut req: Request<Body>,
-) -> Result<Request<Body>, Error>
+    http_client: &Client<C, Full<Bytes>>,
+    mut req: Request<Full<Bytes>>,
+) -> Result<Request<Full<Bytes>>, Error>
 where
     C: Connect + Clone + Sync + Send + 'static,
 {
@@ -302,7 +297,7 @@ pub struct WellKnownServer {
     pub server: String,
 }
 
-/// A connector that can be used with a [`hyper::Client`] that correctly
+/// A connector that can be used with a [`hyper_util::client::legacy::Client`] that correctly
 /// resolves and connects to `matrix://` and `matrix-federation://` URIs.
 #[derive(Debug, Clone)]
 pub struct MatrixConnector {
@@ -340,12 +335,7 @@ impl Service<Uri> for MatrixConnector {
     type Error = Error;
     type Future = ConnectorFuture;
 
-    fn poll_ready(&mut self, _: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // This connector is always ready, but others might not be.
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, dst: Uri) -> Self::Future {
+    fn call(&self, dst: Uri) -> Self::Future {
         let resolver = self.resolver.clone();
         let client_config = self.client_config.clone();
 
@@ -417,184 +407,5 @@ impl Service<Uri> for MatrixConnector {
             Err(format_err!("failed to connect to any endpoint"))
         }
         .boxed()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::{
-        io::Cursor,
-        sync::{Arc, Mutex},
-        task::{self, Poll},
-    };
-
-    use anyhow::Error;
-    use futures::FutureExt;
-    use http::Uri;
-    use hyper::client::connect::Connected;
-    use hyper::client::connect::Connection;
-    use hyper::server::conn::Http;
-    use hyper::service::Service;
-    use tokio::io::{AsyncRead, AsyncWrite};
-
-    type TestConnectorFuture = Pin<Box<dyn Future<Output = Result<TestConnection, Error>> + Send>>;
-
-    /// A connector that returns a connection which returns 200 OK to all connections.
-    #[derive(Clone)]
-    pub struct TestConnector;
-
-    impl Service<Uri> for TestConnector {
-        type Response = TestConnection;
-        type Error = Error;
-        type Future = TestConnectorFuture;
-
-        fn poll_ready(&mut self, _: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-            // This connector is always ready, but others might not be.
-            Poll::Ready(Ok(()))
-        }
-
-        fn call(&mut self, _dst: Uri) -> Self::Future {
-            let (client, server) = TestConnection::double_ended();
-
-            {
-                let service = hyper::service::service_fn(|_| async move {
-                    Ok(hyper::Response::new(hyper::Body::from("Hello World")))
-                        as Result<_, hyper::http::Error>
-                });
-                let fut = Http::new().serve_connection(server, service);
-                tokio::spawn(fut);
-            }
-
-            futures::future::ok(client).boxed()
-        }
-    }
-
-    #[derive(Default)]
-    struct TestConnectionInner {
-        outbound_buffer: Cursor<Vec<u8>>,
-        inbound_buffer: Cursor<Vec<u8>>,
-        wakers: Vec<futures::task::Waker>,
-    }
-
-    /// A in memory connection for use with tests.
-    #[derive(Clone, Default)]
-    pub struct TestConnection {
-        inner: Arc<Mutex<TestConnectionInner>>,
-        direction: bool,
-    }
-
-    impl TestConnection {
-        pub fn double_ended() -> (TestConnection, TestConnection) {
-            let inner: Arc<Mutex<TestConnectionInner>> = Arc::default();
-
-            let a = TestConnection {
-                inner: inner.clone(),
-                direction: false,
-            };
-
-            let b = TestConnection {
-                inner,
-                direction: true,
-            };
-
-            (a, b)
-        }
-    }
-
-    impl AsyncRead for TestConnection {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-            buf: &mut tokio::io::ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            let mut conn = self.inner.lock().expect("mutex");
-
-            let buffer = if self.direction {
-                &mut conn.inbound_buffer
-            } else {
-                &mut conn.outbound_buffer
-            };
-
-            let mut slice = [0; 1024];
-
-            let bytes_read = std::io::Read::read(buffer, &mut slice)?;
-            if bytes_read > 0 {
-                buf.put_slice(&slice[..bytes_read]);
-                Poll::Ready(Ok(()))
-            } else {
-                conn.wakers.push(cx.waker().clone());
-                Poll::Pending
-            }
-        }
-    }
-
-    impl AsyncWrite for TestConnection {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut task::Context<'_>,
-            buf: &[u8],
-        ) -> Poll<Result<usize, std::io::Error>> {
-            let mut conn = self.inner.lock().expect("mutex");
-
-            if self.direction {
-                conn.outbound_buffer.get_mut().extend_from_slice(buf);
-            } else {
-                conn.inbound_buffer.get_mut().extend_from_slice(buf);
-            }
-
-            for waker in conn.wakers.drain(..) {
-                waker.wake()
-            }
-
-            Poll::Ready(Ok(buf.len()))
-        }
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Result<(), std::io::Error>> {
-            let mut conn = self.inner.lock().expect("mutex");
-
-            if self.direction {
-                Pin::new(&mut conn.outbound_buffer).poll_flush(cx)
-            } else {
-                Pin::new(&mut conn.inbound_buffer).poll_flush(cx)
-            }
-        }
-        fn poll_shutdown(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Result<(), std::io::Error>> {
-            let mut conn = self.inner.lock().expect("mutex");
-
-            if self.direction {
-                Pin::new(&mut conn.outbound_buffer).poll_shutdown(cx)
-            } else {
-                Pin::new(&mut conn.inbound_buffer).poll_shutdown(cx)
-            }
-        }
-    }
-
-    impl Connection for TestConnection {
-        fn connected(&self) -> Connected {
-            Connected::new()
-        }
-    }
-
-    #[tokio::test]
-    async fn test_memory_connection() {
-        // TODO: Flesh out tests.
-        let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(TestConnector);
-
-        let response = client
-            .get("http://localhost".parse().unwrap())
-            .await
-            .unwrap();
-
-        assert!(response.status().is_success());
-
-        let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-        assert_eq!(&bytes[..], b"Hello World");
     }
 }


### PR DESCRIPTION
Update `http` dependency to the latest version `1.x`.

 - Since this is a breaking incompatible change in `http` from `0.2.9` to `1.2.0`, a lot of libraries don't interoperate with each other unless they also use `1.x` of `http`. This is why we have a slew of dependent crates being updated.
 - For example, if we're updating `hyper`, then we're going to want `hyper-rustls`, etc to be up to date to get rid of any incompatibility headache. If I had to update one crate, I just updated the whole relevant category.
 - Each crate update comes with it's own set of changes that need to be figured out. Most commits have some references for how I found the upgrade path and recipes.

This is a breaking change so the tagged release version should reflect that.

This is spawning from wanting to update the `http` dependency in the [Secure Border Gateway](https://element.io/server-suite/secure-border-gateways) (SBG) (https://github.com/element-hq/sbg/pull/521).


### Dev notes

 - https://hyper.rs/guides/1/upgrading/