### PR TITLE
Allow providing a custom TLS configuration

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -36,17 +36,35 @@ pub struct FederationClient {
 }
 
 impl FederationClient {
+    /// Create a new client with the given [`Client`].
     pub fn new(client: Client<MatrixConnector, Full<Bytes>>) -> Self {
         FederationClient { client }
     }
 
-    /// Helper function to build a [`FederationClient`].
+    /// Create a new [`FederationClient`] using the given [`MatrixConnector`].
+    ///
+    /// Example with a custom TLS configuration:
+    ///
+    /// ```rust
+    /// use matrix_hyper_federation_client::{FederationClient, MatrixConnector};
+    /// use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+    ///
+    /// let client_config = ClientConfig::builder()
+    ///     .with_root_certificates(RootCertStore::empty())
+    ///     .with_no_client_auth();
+    ///
+    /// let connector = MatrixConnector::with_tls_config(client_config).unwrap();
+    /// let federation_client = FederationClient::with_connector(connector);
+    /// ```
+    pub fn with_connector(connector: MatrixConnector) -> Self {
+        FederationClient::new(Client::builder(TokioExecutor::new()).build(connector))
+    }
+
+    /// Helper function to build a [`FederationClient`] with a default DNS resolver and TLS configuration.
     pub fn new_with_default_resolver() -> Result<FederationClient, Error> {
         let connector = MatrixConnector::with_default_resolver()?;
 
-        Ok(FederationClient {
-            client: Client::builder(TokioExecutor::new()).build(connector),
-        })
+        Ok(FederationClient::with_connector(connector))
     }
 
     pub async fn request(

--- a/src/server_resolver.rs
+++ b/src/server_resolver.rs
@@ -22,7 +22,7 @@ use hyper_util::rt::TokioIo;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
-use tokio_rustls::rustls::ClientConfig;
+use tokio_rustls::rustls::{self, ClientConfig};
 use tower_service::Service;
 use url::Url;
 
@@ -309,20 +309,40 @@ pub struct MatrixConnector {
 }
 
 impl MatrixConnector {
-    /// Create new [`MatrixConnector`] with the given [`MatrixResolver`].
-    pub fn with_resolver(resolver: MatrixResolver) -> MatrixConnector {
-        let client_config = ClientConfig::builder()
-            .with_native_roots()
-            .unwrap()
-            .with_no_client_auth();
-
+    /// Create new [`MatrixConnector`] with the given [`ClientConfig`] and [`MatrixResolver`].
+    pub fn new(client_config: ClientConfig, resolver: MatrixResolver) -> MatrixConnector {
         MatrixConnector {
             resolver,
             client_config,
         }
     }
 
+    /// Create new [`MatrixConnector`] with the given [`MatrixResolver`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the system root certificates cannot be loaded
+    pub fn with_resolver(resolver: MatrixResolver) -> MatrixConnector {
+        let client_config = ClientConfig::builder()
+            .with_native_roots()
+            .unwrap()
+            .with_no_client_auth();
+
+        MatrixConnector::new(client_config, resolver)
+    }
+
+    /// Create new [`MatrixConnector`] with the given [`ClientConfig`] using the default [`MatrixResolver`].
+    pub fn with_tls_config(client_config: ClientConfig) -> Result<MatrixConnector, Error> {
+        let resolver = MatrixResolver::new()?;
+
+        Ok(MatrixConnector::new(client_config, resolver))
+    }
+
     /// Create new [`MatrixConnector`] with a default [`MatrixResolver`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the system root certificates cannot be loaded
     pub fn with_default_resolver() -> Result<MatrixConnector, Error> {
         let resolver = MatrixResolver::new()?;
 


### PR DESCRIPTION
This lets consumers provide a custom `rustls::ClientConfig`, in case they want to customise things like CA certificates